### PR TITLE
python: fix per page key to be string

### DIFF
--- a/web_full_stack/python/reverb_client.py
+++ b/web_full_stack/python/reverb_client.py
@@ -11,7 +11,7 @@ class ReverbClient:
     self._base_uri = base_uri
 
   def listings(self, per_page=10):
-    return self._get('/listings/all', {per_page: per_page})['listings']
+    return self._get('/listings/all', { 'per_page': per_page })['listings']
 
   def categories(self):
     return self._get('/categories/flat')['categories']


### PR DESCRIPTION
our interviewee found this one
the per_page local variable is 10 in this case, w/ the existing syntax python evaluates the variable as the key, ie `{10: 10}`