### PR TITLE
JavaScript: Fix category filtration bug and update Node version requirements

### DIFF
--- a/web_full_stack/js/README.md
+++ b/web_full_stack/js/README.md
@@ -3,7 +3,7 @@ JavaScript Code Extension
 The JS Code Extension is a React application created using [create-react-app](https://github.com/facebook/create-react-app). Tests are written using [enzyme](https://github.com/airbnb/enzyme) and [react-router](https://github.com/ReactTraining/react-router) manages routing.
 
 # Setup
-You'll need [yarn](https://yarnpkg.com/en/) installed and a recent version (>= 10) of [Node](https://nodejs.org/en/) to use this project. If you're using homebrew you can brew install both of those or if you want to manage multiple versions of node on your machine, we suggest using a tool like [nodenv](https://github.com/nodenv/nodenv).
+You'll need [yarn](https://yarnpkg.com/en/) installed and a version of [Node](https://nodejs.org/en/) between v10 and v16, inclusive, to use this project. If you're using homebrew you can brew install both of those or if you want to manage multiple versions of node on your machine, we suggest using a tool like [nodenv](https://github.com/nodenv/nodenv).
 
 * `yarn install` to install dependencies.
 

--- a/web_full_stack/js/src/CategoriesPage.js
+++ b/web_full_stack/js/src/CategoriesPage.js
@@ -17,7 +17,7 @@ function filteredCategories(categories, query) {
   if (!query) { return categories };
 
   return categories.filter((category) => {
-    return category.full_name.match(new RegExp(query, 'i'));
+    return category.full_name.toLowerCase().includes(query.toLowerCase());
   });
 }
 


### PR DESCRIPTION
Hi everyone, I think the JavaScript project has a bug related to filtering the categories. This PR contains a fix for it, plus a documentation update related to the project's Node version requirements.

### 1. Entering an invalid regular expression crashes the app

Here's a screencast showing the original behavior:

![invalid-regex](https://user-images.githubusercontent.com/7143133/217411774-36d3186d-35f7-4ccb-8dfa-62da6174b829.gif)

> Note: The character I typed into the textbox was a backslash (i.e. `\`).

I noticed the [Python](https://github.com/reverbdotcom/code_extension/blob/master/web_full_stack/python/app.py#L19) and [Ruby](https://github.com/reverbdotcom/code_extension/blob/master/web_full_stack/ruby/app/controllers/categories_controller.rb#L12) projects each treat the query as a literal string instead of as a regular expression; so, in this PR, I updated the JavaScript project to do the same. That avoids the issue of whether the query is a valid regular expression or not.

Here's the new behavior:

![string-compare](https://user-images.githubusercontent.com/7143133/217412088-1f2252cf-58d3-4964-9ff8-8cd74e54646c.gif)

Footnote: In case the maintainers do want the app to interpret the query as a regular expression, I'd recommend wrapping the `new RegExp(query, 'i')` expression in a `try/catch` so the app doesn't crash when the query is an invalid regular expression.

---

### 2. `$ yarn start` fails when using Node v17+

The `$ yarn start` command runs OK when using Node v16, but not when using Node v17 or Node v18. When using Node v17 or Node v18, running `$ yarn start` results in the terminal displaying the following error:

```js
$ yarn start

Starting the development server...

...

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (C:\Temp\Code\reverb_code_extension\web_full_stack\js\node_modules\webpack\lib\util\createHash.js:135:53)
    at NormalModule._initBuildHash (C:\Temp\Code\reverb_code_extension\web_full_stack\js\node_modules\webpack\lib\NormalModule.js:417:16)
    at C:\Temp\Code\reverb_code_extension\web_full_stack\js\node_modules\webpack\lib\NormalModule.js:452:10
    at C:\Temp\Code\reverb_code_extension\web_full_stack\js\node_modules\webpack\lib\NormalModule.js:323:13
    at C:\Temp\Code\reverb_code_extension\web_full_stack\js\node_modules\loader-runner\lib\LoaderRunner.js:367:11
    at C:\Temp\Code\reverb_code_extension\web_full_stack\js\node_modules\loader-runner\lib\LoaderRunner.js:233:18
    at context.callback (C:\Temp\Code\reverb_code_extension\web_full_stack\js\node_modules\loader-runner\lib\LoaderRunner.js:111:13)
    at C:\Temp\Code\reverb_code_extension\web_full_stack\js\node_modules\babel-loader\lib\index.js:55:103 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

I Googled the error code (i.e. `ERR_OSSL_EVP_UNSUPPORTED`) and found [this comment on StackOverflow](https://stackoverflow.com/a/69672525), which links to [the Node v17 release notes](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#17.0.0), which mention that error code.

Now that I've read the release notes, I think the gist of the issue is that the JavaScript project is using an OpenSSL feature that is supported (by default) by the OpenSSL version included in Node v16, but is _not_ supported (by default) by the OpenSSL version included in Node v17.

To address this discrepancy; in this PR, I updated the `README.md` to indicate that the latest compatible version of Node is v16. An alternative solution (which I did not implement) is to update the JavaScript project (either its own code or its dependency tree) so that it no longer relies on that OpenSSL feature.

#### Environment

- OS: Windows 10 Enterprise LTSC 2019
- Yarn version: `1.22.19`
- Node versions: `v16.19.0` (runs OK), `v17.9.1` (shows error), and `v18.14.0` (shows error)