### PR TITLE
clean up and standardize instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # Reverb Code Extension
 
-These code extensions are designed so that we can code together during an on-site interview. Our guiding principal is: **we want to see you at your best** .
+These code extensions are designed so that we can collaboratively code together during an interview. Our guiding principal is: **we want to see you at your best** .
 
-## Onsite Instructions
-
-1. Choose the role you are interviewing for ( data / web ) and read the README there.
-2. If you bring your own computer to the interview, please ensure you are ready to go by having anything installed beforehand. If you want to use one of Reverb's computers, please tell us which code editor you prefer and which language you will be doing the extension in.
-3. Familiarize yourself with the problem or the code.
-4. That's it! We'll give you all other information during the coding session.
-
-## Remote Instructions
+## Instructions
 
 1. Choose the role you are interviewing for ( data / web ) and read the README there.
-2. We'll use your machine to drive. Ensure you are ready to go by having anything installed beforehand and that the project can run as-is. If you don't have access to a computer, **let us know** and we'll arrange an alternative setup.
+2. We'll use your machine to drive. Since the interview is conducted using a cloud-based IDE, you do not need to setup anything on your computer besides a web browser. If you don't have access to a computer, **let us know** and we'll arrange an alternative setup.
 3. Familiarize yourself with the problem or the code.
 4. That's it! We'll give you all other information during the coding session.

--- a/data/README.md
+++ b/data/README.md
@@ -21,8 +21,9 @@ In this example, we can see that each event is identified with a unique `userId`
 ## Instructions
 
 1. Familiarize yourself with the [data](logs.txt).
-1. Familiarize yourself with the [app](python/app/) and [tests](python/test/). This is a Python skeleton app provided for ease, but you are encouraged alter it during the interview as you see fit. 
-1. That's it! We'll give you all other information during the coding session.
+1. Familiarize yourself with the [app](python/app/) and [tests](python/test/).
+2. We'll use your machine to drive. Since the interview is conducted using a cloud-based IDE, you do not need to setup anything on your computer besides a web browser. If you don't have access to a computer, **let us know** and we'll arrange an alternative setup.
+3. That's it! We'll give you all other information during the coding session.
 
 ## Other Notes
 

--- a/web_full_stack/README.md
+++ b/web_full_stack/README.md
@@ -1,22 +1,12 @@
 # Reverb Code Extension
 
-This is a code extension designed so that we can code together during an on-site interview. Our guiding principal is: **we want to see you at your best** .
+These code extensions are designed so that we can collaboratively code together during an interview. Our guiding principal is: **we want to see you at your best** .
 
-## Onsite Instructions
+## Instructions
 
-1. Choose which example (Ruby, React, or Python) you would like to extend. If you don't feel comfortable in either of those 3 examples, feel free to implement your own (see "Implementing Your Own Solution"). Again, _we want to see the best side of you_ so please make sure you are comfortable with what we will be working on.
+1. Choose which example (Ruby, React, or Python) you would like to extend.
 
-2. If you bring your own computer to the interview, please ensure you are ready to go by having anything installed beforehand. If you want to use one of Reverb's computers, please tell us which code editor you prefer and which language you will be doing the extension in.
-
-3. Familiarize yourself with the code (or write your own if you prefer) and make sure you understand how it works.
-
-4. That's it! We'll give you all other information during the coding session.
-
-## Remote Instructions
-
-1. Choose which example (Ruby, React, or Python) you would like to extend. Follow the setup instructions for that language. If you don't feel comfortable in either of those 3 examples, feel free to implement your own (see "Implementing Your Own Solution"). Again, _we want to see the best side of you_ so please make sure you are comfortable with what we will be working on.
-
-2. We'll use your machine to drive. Ensure you are ready to go by having anything installed beforehand and that the project can run as-is. If you don't have access to a computer, let us know and we'll arrange an alternative setup.
+2. We'll use your machine to drive. During the interview, the application will run in a cloud-based IDE, so don't worry about running it locally-- all you need is a working web browser! If you don't have access to a computer, let us know and we'll arrange an alternative setup.
 
 3. Familiarize yourself with the code (or write your own if you prefer) and make sure you understand how it works.
 
@@ -27,13 +17,3 @@ This is a code extension designed so that we can code together during an on-site
 1. Our implementations are not 100% complete or refactored in the best possible way. None of the code is gospel, so don't think you have to copy our style in any way. We're open to new ways of doing things as long as we can have a dialogue about it.
 
 2. Our intention is not to trick you or test you; we want to collaborate. So if you have any questions about this, please reach out and ask!
-
-### Implementing Your Own Solution
-
-Again, _you do not need to do this_, but if Ruby / React / Python aren't your jams, we don't want to force you into something you don't know. So, if you'd like to use another language / framework, we welcome that. In that case, please come to the office with code that solves the "Problem" stated below.
-
-We provide an API for developers to create new experiences powered by Reverb. We'd like you to use this API to build a web application with the following features:
-
-- **Category Search** — Given a string, return all categories that contain that string. For example, a search for the category "Electric" would match "Electric Guitars", "Electric Pianos", etc. (Please use https://api.reverb.com/api/categories/flat and make sure you are setting the right headers https://www.reverb-api.com/docs/http-headers ). Hook up a route that renders the results as html (it doesn't need to be pretty, just functional!).
-
-- **Show Listings** — Show the first 10 listings from our API ( https://api.reverb.com/api/listings/all ). Hook up a route that renders the results as html (it doesn't need to be pretty, just functional!).

--- a/web_full_stack/js/README.md
+++ b/web_full_stack/js/README.md
@@ -3,13 +3,14 @@ JavaScript Code Extension
 The JS Code Extension is a React application created using [create-react-app](https://github.com/facebook/create-react-app). Tests are written using [enzyme](https://github.com/airbnb/enzyme) and [react-router](https://github.com/ReactTraining/react-router) manages routing.
 
 # Setup
+
+**During the interview, this application will run in a cloud-based IDE, so don't worry about running it locally. These setup instructions are purely for documentation purposes only.**
+
 You'll need [yarn](https://yarnpkg.com/en/) installed and a recent version (>= 10) of [Node](https://nodejs.org/en/) to use this project. If you're using homebrew you can brew install both of those or if you want to manage multiple versions of node on your machine, we suggest using a tool like [nodenv](https://github.com/nodenv/nodenv).
 
 * `yarn install` to install dependencies.
 
 # Running/Tests
+
 * `yarn start` to start the development server. Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 * `yarn test` to start the test suite.
-
-# That's It
-Really, that's all you have to do. If everything is running, you are ready! We will provide further guidance in the office.

--- a/web_full_stack/python/README.md
+++ b/web_full_stack/python/README.md
@@ -4,6 +4,8 @@ This is the Python/Flask part of the code extension. Tests are written using Pyt
 
 ## Setup
 
+**During the interview, this application will run in a cloud-based IDE, so don't worry about running it locally. These setup instructions are purely for documentation purposes only.**
+
 You'll need [pipenv](https://pypi.org/project/pipenv/) to use this project. If you're using homebrew, you can `brew install pipenv`. After pipenv is installed, do the following:
 
 1. `pipenv install`
@@ -16,6 +18,3 @@ You'll need [pipenv](https://pypi.org/project/pipenv/) to use this project. If y
 
 `pipenv run pytest -vs` runs the test suite
 
-## That's It!
-
-Really, that's it. If you can get things to run, you are ready! We'll provide further direction when you come into the office.

--- a/web_full_stack/ruby/README.md
+++ b/web_full_stack/ruby/README.md
@@ -3,7 +3,10 @@
 This is the Ruby/Rails part of the code extension. Tests are written using Rspec.
 
 ## Setup
-1. Install ruby 3.1.3. We like to use [rbenv](https://github.com/rbenv/rbenv), but do your thing, it's all good.
+
+**During the interview, this application will run in a cloud-based IDE, so don't worry about running it locally. These setup instructions are purely for documentation purposes only.**
+
+1. Install Ruby based on the `.ruby-version` file. We like to use [rbenv](https://github.com/rbenv/rbenv), but do your thing, it's all good.
 
 2. `gem install bundler`
 
@@ -16,7 +19,3 @@ This is the Ruby/Rails part of the code extension. Tests are written using Rspec
 ## Running the tests
 
 `bin/rspec` runs the test suite
-
-## That's It!
-Really, that's it. If you can get things to run, you are ready! We'll provide further direction when you come into the office.
-


### PR DESCRIPTION
what
===

cleans up and standardizes instructions to make them clearer. changes include:
- rewrite instructions with the assumption of cloud-based IDE (hackerrank)
- remove 'bring your own implementation' instructions
- combine on-site and remote instructions

why
===

> - rewrite instructions with the assumption of cloud-based IDE (hackerrank)

afaik, we use hackerrank for all interviews now, so let's remove any expectations to setup the application locally as it'll already be setup in a cloud-based IDE instead. lmk if this is not the case.

> - remove 'bring your own implementation' instructions

this is a rarely used edge case. let's standardize on the existing ruby, python, and js implementations that are ready to spin up in the cloud.

> - combine on-site and remote instructions

afaik, all coding interviews are 100% remote now, so let's remove on-site instructions.